### PR TITLE
Add export as namespace

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
-// TypeScript Version: 2.3
+export as namespace vega;
 
+// TypeScript Version: 2.3
 export * from './types';


### PR DESCRIPTION
Don't we need to explicitly export as vega namspace?

What are users of this package supposed to put in their `tsconfig.json` to use the vega typings?