### PR TITLE
Add "name" as a legal "bind" property.

### DIFF
--- a/types/spec/bind.d.ts
+++ b/types/spec/bind.d.ts
@@ -3,6 +3,7 @@ export interface BaseBinding {
   type?: string;
   element?: Element;
   debounce?: number;
+  name?: string;
 }
 export interface BindCheckbox extends BaseBinding {
   input: 'checkbox';


### PR DESCRIPTION
The "name" property allows for custom labels to be specified. See vega/vega-parser#74. 